### PR TITLE
Allow pass block to to_html method

### DIFF
--- a/lib/later_dude/calendar.rb
+++ b/lib/later_dude/calendar.rb
@@ -36,7 +36,8 @@ module LaterDude
       @block = block
     end
 
-    def to_html
+    def to_html(&block)
+      @block = block if block_given?
       content_tag(:table, :class => "#{@options[:calendar_class]}") do
         content_tag(:thead, "#{show_month_names}#{show_day_names}".html_safe) + content_tag(:tbody, show_days)
       end

--- a/test/calendar_test.rb
+++ b/test/calendar_test.rb
@@ -254,6 +254,17 @@ class CalendarTest < ActiveSupport::TestCase
       assert_no_match %r(<td class="day([^\"]*)otherMonth([^\"]*)"><b>#{day.day}</b></td>), calendar_html2
     end
   end
+  
+  test "allows pass block to to_html method" do
+    proc = lambda do |day|
+      day.day
+    end
+
+    calendar_html1 = LaterDude::Calendar.new(2009, 1, &proc).to_html
+    calendar_html2 = LaterDude::Calendar.new(2009, 1).to_html(&proc)
+
+    assert_equal calendar_html1, calendar_html2
+  end
 
   # TODO: Should I do "real" output testing despite the good coverage of output-related methods? Testing HTML is tedious ...
 end


### PR DESCRIPTION
Sometimes we need pass block after initialize, for example we can init later_dude in controller and render in view. For such situations passing block to to_html method will be useful
