### PR TITLE
Add support for changing tagnames.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 pkg/*
+Gemfile.lock

--- a/test/calendar_test.rb
+++ b/test/calendar_test.rb
@@ -280,5 +280,27 @@ class CalendarTest < ActiveSupport::TestCase
     assert_equal calendar_html1, calendar_html2
   end
 
+  test "allows overriding of html tags" do
+    tags = {
+            :month => :div,
+            :heading => :header,
+            :label => :label,
+            :grid => :section,
+            :week => :div,
+            :day => :article,
+          }
+    calendar = LaterDude::Calendar.new(2012, 7, html_tags: tags, :next_month => "&raquo;")
+    html = calendar.to_html
+    # There should be no colspan on tags other than TH and TD.
+    assert_no_match %r(colspan=), html
+    # There should be no scope on tags other than TH.
+    assert_no_match %r(scope=), html
+    # Each of the tags we define should be found in the output.
+    tags.each do |key, tag|
+      assert_match /<#{tag}/, html
+    end
+    assert_equal html, 'blah'
+  end
+
   # TODO: Should I do "real" output testing despite the good coverage of output-related methods? Testing HTML is tedious ...
 end

--- a/test/calendar_test.rb
+++ b/test/calendar_test.rb
@@ -299,7 +299,6 @@ class CalendarTest < ActiveSupport::TestCase
     tags.each do |key, tag|
       assert_match /<#{tag}/, html
     end
-    assert_equal html, 'blah'
   end
 
   # TODO: Should I do "real" output testing despite the good coverage of output-related methods? Testing HTML is tedious ...


### PR DESCRIPTION
Hi there. I really appreciate a simple approach to rendering a calendar!

My use case required rendering without tables - the idea is that it's more semantic and responsive, though I understand that's debatable. :)

So here's the idea: allow a hash in the options for :html_tags, defaulting to the current tags used by the gem, but allowing us to provide our own tags in our implementation. I've also conditionally disabled some attributes that would be illegal on elements other than TD/TH.

I've provided a test case, and the existing tests pass (not to mention that the output still looks ok in practice when I remove my custom :html_tags hash).

I hope this proves useful!
